### PR TITLE
Run nginx as root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ LABEL \
   Project="https://github.com/jenkins-infra/repo-proxy" \
   Maintainer="infra@lists.jenkins-ci.org"
 
+COPY conf.d/nginx.conf /etc/nginx/nginx.conf
 COPY conf.d/default.conf /etc/nginx/conf.d/default.conf

--- a/conf.d/nginx.conf
+++ b/conf.d/nginx.conf
@@ -1,0 +1,32 @@
+user  root; # Azure File storage on Kubernetes do not support other users than root
+            # but is the only azure blob storage that support many read/write.
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
Azure blob storage use CIFS protocol that do not handle file permissions (Everything is root).
That means that nginx must be run as root user